### PR TITLE
Fixed Null String repesentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -602,11 +602,11 @@ $(BUILD_DIR)/%.ci4: %.ci4.png
 else
 
 $(BUILD_DIR)/%: %.png
-	printf "%s%b" "$(patsubst %.png,%,$^)" '\x00' > $@
+	printf "%s%b" "$(patsubst %.png,%,$^)" > $@
 
 $(BUILD_DIR)/%.inc.c: $(BUILD_DIR)/% %.png
 	hexdump -v -e '1/1 "0x%X,"' $< > $@
-	echo >> $@
+	printf '0x00\n' >> $@
 
 endif
 


### PR DESCRIPTION
Fixed null strings in Makefile that were preventing textures to build correctly in Linux Mint.