### PR TITLE
Fix non-portable printf call in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -602,7 +602,7 @@ $(BUILD_DIR)/%.ci4: %.ci4.png
 else
 
 $(BUILD_DIR)/%: %.png
-	printf "%s%b" "$(patsubst %.png,%,$^)" '\x00' > $@
+	printf "%s%b" "$(patsubst %.png,%,$^)" '\0' > $@
 
 $(BUILD_DIR)/%.inc.c: $(BUILD_DIR)/% %.png
 	hexdump -v -e '1/1 "0x%X,"' $< > $@


### PR DESCRIPTION
Posix printf does not have support for hexadecimal escapes, only for octal ones. This changes it to use to more portable version. The old version did work on Manjaro because it ships with a fancier version of printf, but not on other distros like Debian. Closes #22.