### PR TITLE
SM64 Remain Mod

### DIFF
--- a/launcher/categories.json
+++ b/launcher/categories.json
@@ -406,6 +406,14 @@
         "enabled_by": -1,
         "disabled_by": -1,
         "name": "Skip Cutscenes"
+    }, {
+        "internal_name": "remain_mod",
+        "description": "Allows you to fully complete each level without leaving it.  Please set 'Stay in Course After Getting a Star' to ALWAYS.",
+        "os": OS_ANY,
+        "type": TYPE_BOOL,
+        "enabled_by": -1,
+        "disabled_by": -1,
+        "name": "Remain Mod"
     }],
     "hidden": false,
     "reload_with_preset": true,

--- a/src/engine/level_script.c
+++ b/src/engine/level_script.c
@@ -26,6 +26,7 @@
 #include "surface_load.h"
 
 #include "game/settings.h"
+#include "behavior_data.h"
 
 #define CMD_GET(type, offset) (*(type *) (CMD_PROCESS_OFFSET(offset) + (u8 *) sCurrentCmd))
 
@@ -460,6 +461,221 @@ static void level_cmd_init_mario(void) {
     sCurrentCmd = CMD_NEXT;
 }
 
+static void remain_mod_place_objects(u8 model, s16 px, s16 py, s16 pz, 
+    s16 rx, s16 ry, s16 rz, u32 behArg, void *behScript)
+{
+    struct SpawnInfo *spawnInfo = alloc_only_pool_alloc(sLevelPool, sizeof(struct SpawnInfo));
+
+    spawnInfo->startPos[0] = px;
+    spawnInfo->startPos[1] = py;
+    spawnInfo->startPos[2] = pz;
+
+    spawnInfo->startAngle[0] = rx * 0x8000 / 180;
+    spawnInfo->startAngle[1] = ry * 0x8000 / 180;
+    spawnInfo->startAngle[2] = rz * 0x8000 / 180;
+
+    spawnInfo->areaIndex = sCurrAreaIndex;
+    spawnInfo->activeAreaIndex = sCurrAreaIndex;
+
+    spawnInfo->behaviorArg = behArg;
+    spawnInfo->behaviorScript = behScript;
+    spawnInfo->unk18 = gLoadedGraphNodes[model];
+    spawnInfo->next = gAreas[sCurrAreaIndex].objectSpawnInfos;
+
+    gAreas[sCurrAreaIndex].objectSpawnInfos = spawnInfo;
+}
+
+static void remain_mod_objects(struct SpawnInfo *spawnInfo)
+{
+    void *spinWarpAreaOne = (void *) bhvSpinAirborneWarp; // Warp that occurs at start of each level
+
+    if ((gCurrLevelNum == LEVEL_WF) && (spawnInfo->behaviorScript == spinWarpAreaOne)) 
+    {
+        remain_mod_place_objects(MODEL_NONE, 780, 3784, -625, 0, -45, 0, 0x000D0000, (void *) bhvFadingWarp);
+    }
+    if ((gCurrLevelNum == LEVEL_JRB) && (spawnInfo->behaviorScript == spinWarpAreaOne)) 
+    {
+        remain_mod_place_objects(MODEL_NONE, 5300, 1650, 2500, 0, -90, 0, 0x000B0000, (void *)bhvFadingWarp);
+    }
+    if (gCurrLevelNum == LEVEL_CCM)
+    {
+        // Load assets from Act 5 and Act 2+
+        if ((gCurrActNum == 1) && (sCurrAreaIndex == 1) && (spawnInfo->behaviorScript == (void *)bhvSnowmansHead)) 
+        {
+            remain_mod_place_objects(MODEL_CCM_SNOWMAN_BASE, 2560,  2662, -1122, 0, 0, 0, 0x00000000, (void *)bhvSnowmansBottom);
+        }
+        if ((gCurrActNum == 1) && (sCurrAreaIndex == 2) && (spawnInfo->behaviorScript == (void *)bhvPenguinRaceFinishLine)) 
+        {
+            remain_mod_place_objects(MODEL_PENGUIN, -4952,  6656, -6075, 0, 270, 0, 0x02000000, (void *)bhvRacingPenguin);
+        }
+    }
+    if ((gCurrLevelNum == LEVEL_LLL) && (spawnInfo->behaviorScript == spinWarpAreaOne))
+    {
+        remain_mod_place_objects(MODEL_NONE, 925, 359, 2150, 0, 0, 0, 0x000E0000, (void *)bhvFadingWarp);
+    }
+    if (gCurrLevelNum == LEVEL_SSL)
+    {
+        if (spawnInfo->behaviorScript == spinWarpAreaOne) 
+        {
+            remain_mod_place_objects(MODEL_NONE, -2050, 456, 615, 0, 0, 0, 0x00210000, (void *)bhvFadingWarp);
+        }
+        // Below places a warp after the first object in Area 2
+        if ((spawnInfo->behaviorScript == (void *)bhvAirborneWarp)&&(spawnInfo->behaviorArg == 0x000A0000))
+        {
+            remain_mod_place_objects(MODEL_NONE, 0, 0, 6708, 0, 0, 0, 0x00220000, (void *)bhvFadingWarp);
+        }
+    }
+    if (gCurrLevelNum == LEVEL_DDD)
+    {
+        if ((spawnInfo->behaviorScript == spinWarpAreaOne) && (gCurrActNum == 1))
+        {
+            remain_mod_place_objects(MODEL_MANTA_RAY, -4640, -1380,  40, 0, 0, 0, 0x04000000, (void *)bhvMantaRay);
+        }
+        if (spawnInfo->behaviorScript == (void *)bhvBowserSubDoor) // The first object in Area 2
+        {
+            remain_mod_place_objects(MODEL_NONE, 5960, 310, 4200, 0, -135, 0, 0x000C0000, (void *)bhvFadingWarp);
+            
+            if ((configBowsersSub) && (gCurrActNum != 1)) 
+            {
+                sCurrentCmd = CMD_NEXT; // skip BowserSub
+                sCurrentCmd = CMD_NEXT; // overwrite BowserSubDoor object with this one
+
+                spawnInfo->startPos[0] = CMD_GET(s16, 4);
+                spawnInfo->startPos[1] = CMD_GET(s16, 6);
+                spawnInfo->startPos[2] = CMD_GET(s16, 8);
+
+                spawnInfo->startAngle[0] = CMD_GET(s16, 10) * 0x8000 / 180;
+                spawnInfo->startAngle[1] = CMD_GET(s16, 12) * 0x8000 / 180;
+                spawnInfo->startAngle[2] = CMD_GET(s16, 14) * 0x8000 / 180;
+
+                spawnInfo->behaviorArg = CMD_GET(u32, 16);
+                spawnInfo->behaviorScript = CMD_GET(void *, 20);
+                spawnInfo->unk18 = gLoadedGraphNodes[CMD_GET(u8, 3)];
+            }
+        }
+    }
+    if ((gCurrLevelNum == LEVEL_SL) && (spawnInfo->behaviorScript == spinWarpAreaOne)) 
+    {
+        remain_mod_place_objects(MODEL_NONE, 4350, 1224, 2675, 0, 0, 0, 0x00200000, (void *) bhvFadingWarp);
+    }
+    if ((gCurrLevelNum == LEVEL_TTM) && (spawnInfo->behaviorScript == spinWarpAreaOne))
+    {
+        if (gCurrActNum == 1) // Load assets from Act 2
+        {
+            remain_mod_place_objects(MODEL_UKIKI, 729,  2307,   335, 0, 0, 0, 0x00000000, (void *)bhvUkiki);
+            remain_mod_place_objects(MODEL_TTM_STAR_CAGE, 2496,  1670,  1492, 0, 0, 0, 0x01000000, (void *)bhvUkikiCage);
+        }
+    }
+    if ((gCurrLevelNum == LEVEL_THI) && (spawnInfo->behaviorScript == spinWarpAreaOne))
+    {
+        if (spawnInfo->areaIndex == 1) // THI actually has two spinwarp entrances (big/small)
+        {
+            remain_mod_place_objects(MODEL_NONE, 350, 4091, -1515, 0, 90, 0, 0x000E0000, (void *)bhvFadingWarp);
+
+            if (gCurrActNum == 1) // Load assets from Act 3
+            {
+                remain_mod_place_objects(MODEL_KOOPA_WITH_SHELL, -1900,  -511,  2400, 0, -30, 0, 0x02030000, (void *)bhvKoopa);
+                remain_mod_place_objects(MODEL_NONE, 7400, -1537, -6300, 0, 0, 0, 0x00000000, (void *)bhvKoopaRaceEndpoint);
+            }
+        }
+    }
+    if ((gCurrLevelNum == LEVEL_TTC) && (spawnInfo->behaviorScript == spinWarpAreaOne))
+    {
+        remain_mod_place_objects(MODEL_NONE, 1785, -4822, -720, 0, 0, 0, 0x000B0000, (void *)bhvFadingWarp);
+        remain_mod_place_objects(MODEL_NONE, 1535, -4622, -790, 0, 0, 0, 0x000C0000, (void *)bhvFadingWarp);
+    }
+}
+
+static void remain_mod_create_warp_nodes(u8 id, u8 destLevel, u8 destArea, u8 destNode)
+{
+    struct ObjectWarpNode *warpNode = alloc_only_pool_alloc(sLevelPool, sizeof(struct ObjectWarpNode));
+
+    warpNode->node.id = id;
+    warpNode->node.destLevel = destLevel;
+    warpNode->node.destArea = destArea;
+    warpNode->node.destNode = destNode;
+
+    warpNode->object = NULL;
+
+    warpNode->next = gAreas[sCurrAreaIndex].warpNodes;
+    gAreas[sCurrAreaIndex].warpNodes = warpNode;
+}
+
+static void remain_mod_warp_nodes(struct ObjectWarpNode *warpNode)
+{
+    u8 lastWarpNodeInArea = 0xF1;
+
+    if ((gCurrLevelNum == LEVEL_WF) && (warpNode->node.id == lastWarpNodeInArea))
+    {
+        remain_mod_create_warp_nodes(0x0D, LEVEL_WF, 0x01, 0x0D);
+        remain_mod_create_warp_nodes(0x0E, LEVEL_WF, 0x01, 0x0D);
+    }
+    if ((gCurrLevelNum == LEVEL_JRB) && (warpNode->node.id == lastWarpNodeInArea)) 
+    {
+        if (sCurrAreaIndex == 1)
+        {
+            remain_mod_create_warp_nodes(0x0B, LEVEL_JRB, 0x01, 0x0B);
+        } 
+        else if (sCurrAreaIndex == 2)
+        {
+            remain_mod_create_warp_nodes(0x0C, LEVEL_JRB, 0x01, 0x0B);
+        }
+    }
+    if ((gCurrLevelNum == LEVEL_LLL) && (warpNode->node.id == lastWarpNodeInArea)) 
+    {
+        if (sCurrAreaIndex == 1)
+        {
+            remain_mod_create_warp_nodes(0x0E, LEVEL_LLL, 0x01, 0x0E);
+        } 
+        else if (sCurrAreaIndex == 2)
+        {
+            remain_mod_create_warp_nodes(0x0F, LEVEL_LLL, 0x01, 0x0E);
+            remain_mod_create_warp_nodes(0x20, LEVEL_LLL, 0x01, 0x0E);
+        }
+    }
+    if ((gCurrLevelNum == LEVEL_SSL) && (warpNode->node.id == lastWarpNodeInArea)) 
+    {
+        if (sCurrAreaIndex == 1)
+        {
+            remain_mod_create_warp_nodes(0x21, LEVEL_SSL, 0x01, 0x21);
+        } 
+        else if (sCurrAreaIndex == 2)
+        {
+            remain_mod_create_warp_nodes(0x22, LEVEL_SSL, 0x01, 0x21);
+        }
+        else if (sCurrAreaIndex == 3)
+        {
+            remain_mod_create_warp_nodes(0x23, LEVEL_SSL, 0x01, 0x21);
+        }
+    }
+    if ((gCurrLevelNum == LEVEL_DDD) && (warpNode->node.id == lastWarpNodeInArea))
+    {
+        remain_mod_create_warp_nodes(0x0B, LEVEL_DDD, 0x02, 0x0C);
+        remain_mod_create_warp_nodes(0x0C, LEVEL_DDD, 0x02, 0x0C);
+    }
+    if ((gCurrLevelNum == LEVEL_SL) && (warpNode->node.id == lastWarpNodeInArea))
+    {
+        remain_mod_create_warp_nodes(0x0F, LEVEL_SL, 0x01, 0x20);
+        remain_mod_create_warp_nodes(0x20, LEVEL_SL, 0x01, 0x20);
+    }
+    if ((gCurrLevelNum == LEVEL_THI) && (warpNode->node.id == lastWarpNodeInArea)) 
+    {
+        if (sCurrAreaIndex == 1)
+        {
+            remain_mod_create_warp_nodes(0x0E, LEVEL_THI, 0x01, 0x0E);
+        } 
+        else if (sCurrAreaIndex == 3)
+        {
+            remain_mod_create_warp_nodes(0x0F, LEVEL_THI, 0x01, 0x0E);
+        }
+    }
+    if ((gCurrLevelNum == LEVEL_TTC) && (warpNode->node.id == lastWarpNodeInArea)) 
+    {
+        remain_mod_create_warp_nodes(0x0B, LEVEL_TTC, 0x01, 0x0C);
+        remain_mod_create_warp_nodes(0x0C, LEVEL_TTC, 0x01, 0x0C);
+    }
+}
+
 static void level_cmd_place_object(void) {
     u8 val7 = 1 << (gCurrActNum - 1);
     u16 model;
@@ -509,6 +725,11 @@ static void level_cmd_place_object(void) {
         spawnInfo->next = gAreas[sCurrAreaIndex].objectSpawnInfos;
 
         gAreas[sCurrAreaIndex].objectSpawnInfos = spawnInfo;
+
+        if (configRemainMod)
+        {
+            remain_mod_objects(spawnInfo);
+        }
     }
 
     sCurrentCmd = CMD_NEXT;
@@ -528,6 +749,11 @@ static void level_cmd_create_warp_node(void) {
 
         warpNode->next = gAreas[sCurrAreaIndex].warpNodes;
         gAreas[sCurrAreaIndex].warpNodes = warpNode;
+
+        if (configRemainMod)
+        {
+            remain_mod_warp_nodes(warpNode);
+        }
     }
 
     sCurrentCmd = CMD_NEXT;

--- a/src/engine/level_script.c
+++ b/src/engine/level_script.c
@@ -495,7 +495,7 @@ static void remain_mod_objects(struct SpawnInfo *spawnInfo)
     }
     if ((gCurrLevelNum == LEVEL_JRB) && (spawnInfo->behaviorScript == spinWarpAreaOne)) 
     {
-        remain_mod_place_objects(MODEL_NONE, 5300, 1650, 2500, 0, -90, 0, 0x000B0000, (void *)bhvFadingWarp);
+        remain_mod_place_objects(MODEL_NONE, 5250, 1650, 2500, 0, -90, 0, 0x000B0000, (void *)bhvFadingWarp);
     }
     if (gCurrLevelNum == LEVEL_CCM)
     {
@@ -586,6 +586,23 @@ static void remain_mod_objects(struct SpawnInfo *spawnInfo)
     }
 }
 
+static void remain_mod_create_whirlpool(u8 index, u8 id, s16 pX, s16 pY, s16 pZ, s16 strength) 
+{
+    struct Whirlpool *whirlpool;
+
+    if (sCurrAreaIndex != -1 && index < 2) 
+    {
+        if ((whirlpool = gAreas[sCurrAreaIndex].whirlpools[index]) == NULL) 
+        {
+            whirlpool = alloc_only_pool_alloc(sLevelPool, sizeof(struct Whirlpool));
+            gAreas[sCurrAreaIndex].whirlpools[index] = whirlpool;
+        }
+
+        vec3s_set(whirlpool->pos, pX, pY, pZ);
+        whirlpool->strength = strength;
+    }
+}
+
 static void remain_mod_create_warp_nodes(u8 id, u8 destLevel, u8 destArea, u8 destNode)
 {
     struct ObjectWarpNode *warpNode = alloc_only_pool_alloc(sLevelPool, sizeof(struct ObjectWarpNode));
@@ -615,6 +632,12 @@ static void remain_mod_warp_nodes(struct ObjectWarpNode *warpNode)
         if (sCurrAreaIndex == 1)
         {
             remain_mod_create_warp_nodes(0x0B, LEVEL_JRB, 0x01, 0x0B);
+
+            if (gCurrActNum == 1) 
+            {
+                // Create whirlpool with strength (-30) set to zero
+                remain_mod_create_whirlpool(0, 3, 4979, -5222, 2482, 0);
+            }
         } 
         else if (sCurrAreaIndex == 2)
         {
@@ -650,13 +673,25 @@ static void remain_mod_warp_nodes(struct ObjectWarpNode *warpNode)
     }
     if ((gCurrLevelNum == LEVEL_DDD) && (warpNode->node.id == lastWarpNodeInArea))
     {
-        remain_mod_create_warp_nodes(0x0B, LEVEL_DDD, 0x02, 0x0C);
-        remain_mod_create_warp_nodes(0x0C, LEVEL_DDD, 0x02, 0x0C);
+        if (sCurrAreaIndex == 2)
+        {
+            remain_mod_create_warp_nodes(0x0B, LEVEL_DDD, 0x02, 0x0C);
+            remain_mod_create_warp_nodes(0x0C, LEVEL_DDD, 0x02, 0x0C);
+
+            if ((gCurrActNum == 1) && (configBowsersSub))
+            {
+                // Create whirlpool with strength (50) set to zero
+                remain_mod_create_whirlpool(1, 2, 3917, -2040, -6041, 0);
+            }
+        }
     }
     if ((gCurrLevelNum == LEVEL_SL) && (warpNode->node.id == lastWarpNodeInArea))
     {
-        remain_mod_create_warp_nodes(0x0F, LEVEL_SL, 0x01, 0x20);
-        remain_mod_create_warp_nodes(0x20, LEVEL_SL, 0x01, 0x20);
+        if (sCurrAreaIndex == 1) 
+        {
+            remain_mod_create_warp_nodes(0x0F, LEVEL_SL, 0x01, 0x20);
+            remain_mod_create_warp_nodes(0x20, LEVEL_SL, 0x01, 0x20);
+        }
     }
     if ((gCurrLevelNum == LEVEL_THI) && (warpNode->node.id == lastWarpNodeInArea)) 
     {

--- a/src/game/behaviors/ddd_sub.inc.c
+++ b/src/game/behaviors/ddd_sub.inc.c
@@ -1,6 +1,15 @@
 // ddd_sub.c.inc
 
 void bhv_bowsers_sub_loop(void) {
+    if (configRemainMod)
+    {
+        if (!configBowsersSub && (save_file_get_flags() & (SAVE_FLAG_HAVE_KEY_2 | SAVE_FLAG_UNLOCKED_UPSTAIRS_DOOR))) 
+        {
+            obj_mark_for_deletion(o);
+        }
+        return;
+    }
+
     if ((configBowsersSub && gCurrActNum >= 2) ||
     (!configBowsersSub && (save_file_get_flags() & (SAVE_FLAG_HAVE_KEY_2 | SAVE_FLAG_UNLOCKED_UPSTAIRS_DOOR))))
         obj_mark_for_deletion(o);

--- a/src/game/behaviors/koopa.inc.c
+++ b/src/game/behaviors/koopa.inc.c
@@ -772,6 +772,7 @@ static void koopa_the_quick_act_after_race(void) {
                 o->oSubAction = 2;
                 o->oMoveFlags = 0;
                 cur_obj_init_animation_with_sound(12);
+                cur_obj_play_sound_2(SOUND_GENERAL_BOING2_LOWPRIO); // Boing
             }
         }
     } else if (o->parentObj->oKoopaRaceEndpointRaceStatus != 0) {

--- a/src/game/behaviors/koopa.inc.c
+++ b/src/game/behaviors/koopa.inc.c
@@ -6,6 +6,7 @@
  * which assists in determining the state of the race. It is positioned at the
  * flag.
  */
+#include "../settings.h"
 
 /**
  * Hitbox for koopa - this is used for every form except Koopa the Quick, which
@@ -521,6 +522,16 @@ static void koopa_the_quick_act_show_init_text(void) {
     s32 response = obj_update_race_proposition_dialog(
         sKoopaTheQuickProperties[o->oKoopaTheQuickRaceIndex].initText);
 
+    if ((configRemainMod) && (gCurrCourseNum == COURSE_BOB))
+    {
+        struct Object *checkForFlag = cur_obj_nearest_object_with_behavior(bhvKoopaRaceEndpoint);
+
+        if (checkForFlag == NULL) 
+        {
+            spawn_object_abs_with_rot_degrees(o, 0, MODEL_NONE, bhvKoopaRaceEndpoint, 0x00000000, 3304, 4242, -4603, 0, 0, 0);
+        }
+    }
+
     if (response == DIALOG_RESPONSE_YES) {
         UNUSED s32 unused;
 
@@ -751,6 +762,17 @@ static void koopa_the_quick_act_after_race(void) {
         if (dialogResponse != 0) {
             o->parentObj->oKoopaRaceEndpointDialog = DIALOG_NONE;
             o->oTimer = 0;
+
+            // Lost or cheated in Bob-Omb Race:
+            if ((configRemainMod) && (gCurrCourseNum == COURSE_BOB) && (o->parentObj->oKoopaRaceEndpointRaceStatus == 0))
+            {
+                // JUMP
+                o->oVelY = 140.0f;
+                o->oGravity = -6.0f;
+                o->oSubAction = 2;
+                o->oMoveFlags = 0;
+                cur_obj_init_animation_with_sound(12);
+            }
         }
     } else if (o->parentObj->oKoopaRaceEndpointRaceStatus != 0) {
         spawn_default_star(sKoopaTheQuickProperties[o->oKoopaTheQuickRaceIndex].starPos[0],
@@ -758,6 +780,18 @@ static void koopa_the_quick_act_after_race(void) {
                    sKoopaTheQuickProperties[o->oKoopaTheQuickRaceIndex].starPos[2]);
 
         o->parentObj->oKoopaRaceEndpointRaceStatus = 0;
+    }
+
+    if ((configRemainMod) && (gCurrCourseNum == COURSE_BOB) && (o->oPosY > 5500))
+    {
+        spawn_object_abs_with_rot_degrees(o, 0, MODEL_KOOPA_WITH_SHELL, bhvKoopa, 0x01020000, -4004, 0, 5221, 0, 0, 0);
+        o->parentObj->oKoopaRaceEndpointKoopaFinished = FALSE;
+        o->parentObj->oKoopaRaceEndpointRaceBegun = FALSE;
+        o->parentObj->oKoopaRaceEndpointRaceEnded = FALSE;
+        o->parentObj->oKoopaRaceEndpointRaceStatus = 0;
+        o->parentObj->oKoopaRaceEndpointDialog = 0;
+        o->parentObj = o;
+        obj_mark_for_deletion(o);
     }
 }
 

--- a/src/game/behaviors/snowman.inc.c
+++ b/src/game/behaviors/snowman.inc.c
@@ -178,6 +178,11 @@ void bhv_snowmans_head_init(void) {
     o->oFriction = 0.999f;
     o->oBuoyancy = 2.0f;
 
+    if (configRemainMod)
+    {
+        return;
+    }
+
     if ((sp37 & (1 << sp36)) && gCurrActNum != sp36 + 1) {
         spawn_object_abs_with_rot(o, 0, MODEL_CCM_SNOWMAN_BASE, bhvBigSnowmanWhole, -4230, -1344, 1813,
                                   0, 0, 0);

--- a/src/game/interaction.c
+++ b/src/game/interaction.c
@@ -771,6 +771,104 @@ u32 interact_water_ring(struct MarioState *m, UNUSED u32 interactType, struct Ob
     return FALSE;
 }
 
+void remain_mod_spawn_objects(struct Object *o)
+{
+    if ((gCurrCourseNum == COURSE_BOB) && (gLastCompletedStarNum == 1))
+    {
+        struct Object *objToDelete;
+
+        // Delete Cannon + Barrel at start of level
+        objToDelete = find_nearest_object_with_behavior(bhvCannonBarrelBubbles, -5694, 128, 5600);
+        if (objToDelete != NULL) 
+        {
+            obj_mark_for_deletion(objToDelete->parentObj); // bhvWaterBombCannon
+            obj_mark_for_deletion(objToDelete);
+        }
+
+        // Delete both Bob-Omb Buddies
+        for (int i = 0; i < 2; i++) 
+        {
+            objToDelete = cur_obj_nearest_object_with_behavior(bhvBobombBuddy);
+            if (objToDelete != NULL) 
+            {
+                obj_mark_for_deletion(objToDelete);
+            }
+        }
+
+        // Delete both Bowling Balls in Pit
+        for (int i = 0; i < 2; i++) 
+        {
+            objToDelete = cur_obj_nearest_object_with_behavior(bhvPitBowlingBall);
+            if (objToDelete != NULL) 
+            {
+                obj_mark_for_deletion(objToDelete);
+            }
+        }
+
+        // Delete existing BowlingBallSpawners - NOTE: This usually happens in Act 3
+        for (int i = 0; i < 2; i++) 
+        {
+            objToDelete = cur_obj_nearest_object_with_behavior(bhvBobBowlingBallSpawner);
+
+            if (objToDelete != NULL) 
+            {
+                obj_mark_for_deletion(objToDelete);
+            }
+        }
+        
+        // Spawn faster BowlingBallSpawners + small koopa - NOTE: This usually happens in Act 3
+        spawn_object_abs_with_rot_degrees(o, 0, MODEL_NONE, bhvTtmBowlingBallSpawner, 0x00000000, 1535, 3840, -5561, 0, 0, 0);
+        spawn_object_abs_with_rot_degrees(o, 0, MODEL_NONE, bhvTtmBowlingBallSpawner, 0x00020000, 524, 2825, -5400, 0, 0, 0);
+        spawn_object_abs_with_rot_degrees(o, 0, MODEL_KOOPA_WITH_SHELL, bhvKoopa, 0x00010000, 3400,  770,  6500, 0, 0, 0);
+
+        // Spawn Act 2 Objects
+        spawn_object_abs_with_rot_degrees(o, 0, MODEL_BOWLING_BALL, bhvPitBowlingBall, 0x00000000, -993,  886, -3565, 0, 0, 0);
+        spawn_object_abs_with_rot_degrees(o, 0, MODEL_BOWLING_BALL, bhvPitBowlingBall, 0x00000000, -785,  886, -4301, 0, 0, 0);
+        spawn_object_abs_with_rot_degrees(o, 0, MODEL_BOWLING_BALL, bhvPitBowlingBall, 0x00000000, -93, 886, -3414, 0, 0, 0);
+        spawn_object_abs_with_rot_degrees(o, 0, MODEL_DL_CANNON_LID, bhvCannonClosed, 0x00000000, -5694, 128, 5600, 0, 180, 0);
+        spawn_object_abs_with_rot_degrees(o, 0, MODEL_KOOPA_WITH_SHELL, bhvKoopa, 0x01020000, -4004, 0, 5221, 0, 0, 0);
+        spawn_object_abs_with_rot_degrees(o, 0, MODEL_BOBOMB_BUDDY, bhvBobombBuddyOpensCannon, 0x00000000, -5723,  140,  6017, 0, 0, 0);
+        spawn_object_abs_with_rot_degrees(o, 0, MODEL_BOBOMB_BUDDY, bhvBobombBuddy, DIALOG_003 << 16, -6250, 0, 6680, 0, 0, 0);
+    }
+    if ((gCurrCourseNum == COURSE_WF) && (gLastCompletedStarNum == 1))
+    {
+        spawn_object_abs_with_rot_degrees(o, 0, MODEL_NONE, bhvFadingWarp, 0x000E0000, 180, 3584, 340, 0, 0, 0);
+    }
+    if ((gCurrCourseNum == COURSE_JRB) && (gLastCompletedStarNum == 1))
+    {
+        spawn_object_abs_with_rot_degrees(o, 0, MODEL_NONE, bhvFadingWarp, 0x000C0000, 0, 1258, 3000, 0, 0, 0);
+    }
+    if ((gCurrCourseNum == COURSE_BBH) && (gLastCompletedStarNum == 1))
+    {
+        spawn_object_abs_with_rot_degrees(o, 0, MODEL_NONE, bhvFlamethrower, 0x00030000, 990, -2146, -908, 0, -45, 0);
+        spawn_object_abs_with_rot_degrees(o, 0, MODEL_NONE, bhvMerryGoRoundBooManager, 0x01000000, -1100, -2372, 1100, 0, 135, 0);
+    }
+    if ((gCurrCourseNum == COURSE_LLL) && (gLastCompletedStarNum == 5))
+    {
+        spawn_object_abs_with_rot_degrees(o, 0, MODEL_NONE, bhvFadingWarp, 0x000F0000, 2520, 3591, -910, 0, 0, 0);
+    }
+    if ((gCurrCourseNum == COURSE_LLL) && (gLastCompletedStarNum == 6))
+    {
+        spawn_object_abs_with_rot_degrees(o, 0, MODEL_NONE, bhvFadingWarp, 0x00200000, 1805, 3232, 1440, 0, 0, 0);
+    }
+    if ((gCurrCourseNum == COURSE_SSL) && (gLastCompletedStarNum == 4))
+    {
+        spawn_object_abs_with_rot_degrees(o, 0, MODEL_NONE, bhvFadingWarp, 0x00230000, 0, -1176, -3700, 0, 0, 0);
+    }
+    if ((gCurrCourseNum == COURSE_DDD) && (gLastCompletedStarNum == 1))
+    {
+        spawn_object_abs_with_rot_degrees(o, 0, MODEL_NONE, bhvFadingWarp, 0x000B0000, 3900, 571, -600, 0, 0, 0);
+    }
+    if ((gCurrCourseNum == COURSE_SL) && (gLastCompletedStarNum == 3))
+    {
+        spawn_object_abs_with_rot_degrees(o, 0, MODEL_NONE, bhvFadingWarp, 0x000F0000, 4350, 1229, 4350, 0, 0, 0);
+    }
+    if ((gCurrCourseNum == COURSE_THI) && (gLastCompletedStarNum == 6))
+    {
+        spawn_object_abs_with_rot_degrees(o, 0, MODEL_NONE, bhvFadingWarp, 0x000F0000, 0, 1843, 0, 0, 0, 0);
+    }
+}
+
 u32 interact_star_or_key(struct MarioState *m, UNUSED u32 interactType, struct Object *o) {
     u32 starIndex;
     u32 starGrabAction = ACT_STAR_DANCE_EXIT;
@@ -853,6 +951,11 @@ u32 interact_star_or_key(struct MarioState *m, UNUSED u32 interactType, struct O
 #ifndef VERSION_JP
         update_mario_sound_and_camera(m);
 #endif
+
+        if (configRemainMod)
+        {
+            remain_mod_spawn_objects(o);
+        }
 
         if (grandStar) {
             return set_mario_action(m, ACT_JUMBO_STAR_CUTSCENE, 0);

--- a/src/game/interaction.c
+++ b/src/game/interaction.c
@@ -855,7 +855,7 @@ void remain_mod_spawn_objects(struct Object *o)
     {
         spawn_object_abs_with_rot_degrees(o, 0, MODEL_NONE, bhvFadingWarp, 0x00230000, 0, -1176, -3700, 0, 0, 0);
     }
-    if ((gCurrCourseNum == COURSE_DDD) && (gLastCompletedStarNum == 1))
+    if ((gCurrCourseNum == COURSE_DDD) && (gLastCompletedStarNum == 1) && (configBowsersSub))
     {
         spawn_object_abs_with_rot_degrees(o, 0, MODEL_NONE, bhvFadingWarp, 0x000B0000, 3900, 571, -600, 0, 0, 0);
     }

--- a/src/game/level_update.c
+++ b/src/game/level_update.c
@@ -545,6 +545,8 @@ void remain_mod_load_area()
         spawn_object_abs_with_rot_degrees(spawnNode->object, 0, MODEL_NONE, bhvJetStream, 0x00000000, 4988, -5221,  2473, 0, 0, 0);
         spawn_object_abs_with_rot_degrees(spawnNode->object, 0, MODEL_BOBOMB_BUDDY, bhvBobombBuddyOpensCannon, 0x00000000, -1956,  1331,  6500, 0, 0, 0);
         spawn_object_abs_with_rot_degrees(spawnNode->object, 0, MODEL_UNAGI, bhvUnagi, 0x01010000, 8270, -3130,  1846, 0, 285, 0);
+
+        gCurrentArea->whirlpools[0]->strength = -30;
     }
     if ((gCurrCourseNum == COURSE_DDD) && (spawnNode->object->oBehParams == 0x000C0000))
     {
@@ -571,6 +573,8 @@ void remain_mod_load_area()
         spawn_object_abs_with_rot_degrees(spawnNode->object, 0, MODEL_DDD_POLE, bhvDDDPole, 0x00170000, 5760, 1005,   360, 0, 270, 0);
         spawn_object_abs_with_rot_degrees(spawnNode->object, 0, MODEL_DDD_POLE, bhvDDDPole, 0x00170000, 3310, 1005, -1945, 0,   0, 0);
         spawn_object_abs_with_rot_degrees(spawnNode->object, 0, MODEL_DDD_POLE, bhvDDDPole, 0x000D0000, 3550, 1005, -2250, 0,   0, 0);
+
+        gCurrentArea->whirlpools[1]->strength = 50;
     }
     if ((gCurrCourseNum == COURSE_TTC) && (spawnNode->object->oBehParams == 0x000C0000))
     {

--- a/src/game/level_update.c
+++ b/src/game/level_update.c
@@ -30,6 +30,9 @@
 #include "level_table.h"
 #include "course_table.h"
 #include "rumble_init.h"
+#include "behavior_data.h"
+#include "object_helpers.h"
+#include "macro_special_objects.h"
 
 #include "settings.h"
 
@@ -474,6 +477,109 @@ void init_mario_after_warp(void) {
     }
 }
 
+void remain_mod_load_area()
+{
+    struct ObjectWarpNode *spawnNode = area_get_warp_node(sWarpDest.nodeId);
+
+    if ((gCurrCourseNum == COURSE_WF) && (spawnNode->object->oBehParams == 0x000D0000))
+    {
+        spawn_object_abs_with_rot_degrees(spawnNode->object, 0, MODEL_LEVEL_GEOMETRY_08, bhvTower, 0x00000000, 0, 3584, 0, 0, 0, 0);
+        spawn_object_abs_with_rot_degrees(spawnNode->object, 0, MODEL_NONE, bhvTowerPlatformGroup, 0x00000000, 0, 3483, 0, 0, 0, 0);
+        spawn_object_abs_with_rot_degrees(spawnNode->object, 0, MODEL_WF_TOWER_DOOR, bhvTowerDoor, 0x00000000, -511, 3584, 0, 0, 0, 0);
+        spawn_object_abs_with_rot_degrees(spawnNode->object, 0, MODEL_WF_KICKABLE_BOARD, bhvKickableBoard, 0x00000000, 13, 3584, -1407, 0, 315, 0);
+        spawn_object_abs_with_rot_degrees(spawnNode->object, 0, MODEL_1UP, bhv1Up, 0x00000000, -384, 3584, 6, 0, 0, 0);
+        spawn_object_abs_with_rot_degrees(spawnNode->object, 0, MODEL_BULLET_BILL, bhvBulletBill, 0x00000000, 1280, 3712, 968, 0, 180, 0);
+        spawn_object_abs_with_rot_degrees(spawnNode->object, 0, MODEL_LEVEL_GEOMETRY_09, bhvBulletBillCannon, 0x00000000, 1280, 3584, 896, 0, 0, 0);
+        spawn_object_abs_with_rot_degrees(spawnNode->object, 0, MODEL_STAR, bhvStar, 0x01000000, 300, 5550, 0, 0, 0, 0);
+        spawn_object_abs_with_rot_degrees(spawnNode->object, 0, MODEL_BOBOMB_BUDDY, bhvBobombBuddyOpensCannon, 0x00000000, -1700, 1140,  3500, 0, 0, 0);
+        spawn_object_abs_with_rot_degrees(spawnNode->object, 0, MODEL_HOOT, bhvHoot, 0x00000000, 2560,  700,  4608, 0, 0, 0);
+    }
+    if ((gCurrCourseNum == COURSE_JRB) && (spawnNode->object->oBehParams == 0x000B0000))
+    {
+        set_camera_mode(gMarioState->area->camera, CAMERA_MODE_FREE_ROAM, 1); // Fixes a bug where camera is set to CAMERA_MODE_BEHIND_MARIO for some reason
+
+        struct Object *objToDelete;
+
+        objToDelete = cur_obj_nearest_object_with_behavior(bhvUnagi);
+        if (objToDelete != NULL) 
+        {
+            obj_mark_for_deletion(objToDelete);
+        }
+
+        for (int i = 0; i < 2; i++) 
+        {
+            objToDelete = cur_obj_nearest_object_with_behavior(bhvSunkenShipPart);
+            if (objToDelete != NULL) {
+                obj_mark_for_deletion(objToDelete);
+            }
+        }
+
+        for (int i = 0; i < 2; i++) 
+        {
+            objToDelete = cur_obj_nearest_object_with_behavior(bhvSunkenShipPart2);
+            if (objToDelete != NULL) 
+            {
+                obj_mark_for_deletion(objToDelete);
+            }
+        }
+
+        objToDelete = cur_obj_nearest_object_with_behavior(bhvInSunkenShip);
+        if (objToDelete != NULL) 
+        {
+            obj_mark_for_deletion(objToDelete);
+        }
+
+        objToDelete = cur_obj_nearest_object_with_behavior(bhvInSunkenShip2);
+        if (objToDelete != NULL) 
+        {
+            obj_mark_for_deletion(objToDelete);
+        }
+
+        spawn_object_abs_with_rot_degrees(spawnNode->object, 0, MODEL_STAR, bhvStar, 0x05000000, 5000, -4800,  2500, 0, 0, 0);
+        spawn_object_abs_with_rot_degrees(spawnNode->object, 0, MODEL_JRB_SHIP_LEFT_HALF_PART, bhvShipPart3, 0x00000000, 4880,   820,  2375, 0, 0, 0);
+        spawn_object_abs_with_rot_degrees(spawnNode->object, 0, MODEL_JRB_SHIP_BACK_LEFT_PART, bhvShipPart3, 0x00000000, 4880,   820,  2375, 0, 0, 0);
+        spawn_object_abs_with_rot_degrees(spawnNode->object, 0, MODEL_JRB_SHIP_RIGHT_HALF_PART, bhvShipPart3, 0x00000000, 4880,   820,  2375, 0, 0, 0);
+        spawn_object_abs_with_rot_degrees(spawnNode->object, 0, MODEL_JRB_SHIP_BACK_RIGHT_PART, bhvShipPart3, 0x00000000, 4880,   820,  2375, 0, 0, 0);
+        spawn_object_abs_with_rot_degrees(spawnNode->object, 0, MODEL_NONE, bhvInSunkenShip3, 0x00000000, 4880,   820,  2375, 0, 0, 0);
+        spawn_object_abs_with_rot_degrees(spawnNode->object, 0, MODEL_JRB_SLIDING_BOX, bhvJrbSlidingBox, 0x00000000, 4668,  1434,  2916, 0, 0, 0);
+        spawn_object_abs_with_rot_degrees(spawnNode->object, 0, MODEL_NONE, bhvJetStream, 0x00000000, 4988, -5221,  2473, 0, 0, 0);
+        spawn_object_abs_with_rot_degrees(spawnNode->object, 0, MODEL_BOBOMB_BUDDY, bhvBobombBuddyOpensCannon, 0x00000000, -1956,  1331,  6500, 0, 0, 0);
+        spawn_object_abs_with_rot_degrees(spawnNode->object, 0, MODEL_UNAGI, bhvUnagi, 0x01010000, 8270, -3130,  1846, 0, 285, 0);
+    }
+    if ((gCurrCourseNum == COURSE_DDD) && (spawnNode->object->oBehParams == 0x000C0000))
+    {
+        struct Object *objToDelete;
+
+        objToDelete = cur_obj_nearest_object_with_behavior(bhvBowserSubDoor);
+        if (objToDelete != NULL)
+        {
+            obj_mark_for_deletion(objToDelete);
+        }
+
+        objToDelete = cur_obj_nearest_object_with_behavior(bhvBowsersSub);
+        if (objToDelete != NULL)
+        {
+            obj_mark_for_deletion(objToDelete);
+        }
+
+        spawn_object_abs_with_rot_degrees(spawnNode->object, 0, MODEL_DDD_POLE, bhvDDDPole, 0x001E0000, 5120, 1005,  3584, 0, 180, 0);
+        spawn_object_abs_with_rot_degrees(spawnNode->object, 0, MODEL_DDD_POLE, bhvDDDPole, 0x00150000, 5605, 1005,  3380, 0, 270, 0);
+        spawn_object_abs_with_rot_degrees(spawnNode->object, 0, MODEL_DDD_POLE, bhvDDDPole, 0x000B0000, 1800, 1005,  1275, 0,   0, 0);
+        spawn_object_abs_with_rot_degrees(spawnNode->object, 0, MODEL_DDD_POLE, bhvDDDPole, 0x000B0000, 4000, 1005,  1075, 0, 180, 0);
+        spawn_object_abs_with_rot_degrees(spawnNode->object, 0, MODEL_DDD_POLE, bhvDDDPole, 0x00140000, 1830, 1005,   520, 0, 270, 0);
+        spawn_object_abs_with_rot_degrees(spawnNode->object, 0, MODEL_DDD_POLE, bhvDDDPole, 0x000B0000, 4000, 1005,  1275, 0,   0, 0);
+        spawn_object_abs_with_rot_degrees(spawnNode->object, 0, MODEL_DDD_POLE, bhvDDDPole, 0x00170000, 5760, 1005,   360, 0, 270, 0);
+        spawn_object_abs_with_rot_degrees(spawnNode->object, 0, MODEL_DDD_POLE, bhvDDDPole, 0x00170000, 3310, 1005, -1945, 0,   0, 0);
+        spawn_object_abs_with_rot_degrees(spawnNode->object, 0, MODEL_DDD_POLE, bhvDDDPole, 0x000D0000, 3550, 1005, -2250, 0,   0, 0);
+    }
+    if ((gCurrCourseNum == COURSE_TTC) && (spawnNode->object->oBehParams == 0x000C0000))
+    {
+        gTTCSpeedSetting = (gTTCSpeedSetting + 1) % 4;
+        despawn_macro_objects(gCurrentArea->macroObjects);
+        spawn_macro_objects(1, gCurrentArea->macroObjects);
+    }
+}
+
 // used for warps inside one level
 void warp_area(void) {
     if (sWarpDest.type != WARP_TYPE_NOT_WARPING) {
@@ -484,6 +590,11 @@ void warp_area(void) {
         }
 
         init_mario_after_warp();
+
+        if (configRemainMod)
+        {
+            remain_mod_load_area();
+        }
     }
 }
 

--- a/src/game/macro_special_objects.h
+++ b/src/game/macro_special_objects.h
@@ -11,6 +11,7 @@ void spawn_macro_abs_yrot_2params(s32 model, const BehaviorScript *behavior, s16
 void spawn_macro_abs_yrot_param1(s32 model, const BehaviorScript *behavior, s16 x, s16 y, s16 z, s16 ry, s16 params);
 void spawn_macro_abs_special(s32 model, const BehaviorScript *behavior, s16 x, s16 y, s16 z, s16 unkA, s16 unkB, s16 unkC);
 
+void despawn_macro_objects(s16 *macroObjList);
 void spawn_macro_objects(s16 areaIndex, s16 *macroObjList);
 void spawn_macro_objects_hardcoded(s16 areaIndex, s16 *macroObjList);
 void spawn_special_objects(s16 areaIndex, s16 **specialObjList);

--- a/src/game/object_helpers.h
+++ b/src/game/object_helpers.h
@@ -92,6 +92,9 @@ s16 obj_turn_toward_object(struct Object *obj, struct Object *target, s16 angleI
 void obj_set_parent_relative_pos(struct Object *obj, s16 relX, s16 relY, s16 relZ);
 void obj_set_pos(struct Object *obj, s16 x, s16 y, s16 z);
 void obj_set_angle(struct Object *obj, s16 pitch, s16 yaw, s16 roll);
+struct Object *spawn_object_abs_with_rot_degrees(struct Object *parent, s16 uselessArg, u32 model,
+                                                 const BehaviorScript *behavior, s32 behPar, s16 x,
+                                                 s16 y, s16 z, s16 rx, s16 ry, s16 rz);
 struct Object *spawn_object_abs_with_rot(struct Object *parent, s16 uselessArg, u32 model,
                                          const BehaviorScript *behavior,
                                          s16 x, s16 y, s16 z, s16 rx, s16 ry, s16 rz);
@@ -138,6 +141,7 @@ u32 get_object_list_from_behavior(const BehaviorScript *behavior);
 struct Object *cur_obj_nearest_object_with_behavior(const BehaviorScript *behavior);
 f32 cur_obj_dist_to_nearest_object_with_behavior(const BehaviorScript* behavior);
 struct Object *cur_obj_find_nearest_object_with_behavior(const BehaviorScript * behavior, f32 *dist);
+struct Object *find_nearest_object_with_behavior(const BehaviorScript *behavior, f32 x, f32 y, f32 z);
 struct Object *find_unimportant_object(void);
 s32 count_unimportant_objects(void);
 s32 count_objects_with_behavior(const BehaviorScript *behavior);

--- a/src/game/settings.c
+++ b/src/game/settings.c
@@ -201,6 +201,7 @@ s8 configFixExploits = 0;
 
 s8 configBowsersSub = 1;
 unsigned int configStayInCourse = 0;
+unsigned int configRemainMod = 0;
 s8 configSkipMissionSelect = 0;
 s8 configSwitchToNextMission = 0;
 s8 configSkipCutscenes = 0;

--- a/src/game/settings.h
+++ b/src/game/settings.h
@@ -50,6 +50,7 @@ extern s8 configFixExploits;
 
 extern s8 configBowsersSub;
 extern unsigned int configStayInCourse;
+extern unsigned int configRemainMod;
 extern s8 configSkipMissionSelect;
 extern s8 configSwitchToNextMission;
 extern s8 configSkipCutscenes;

--- a/src/pc/configfile.c
+++ b/src/pc/configfile.c
@@ -89,6 +89,7 @@ static const struct ConfigOption options[] = {
     { .name = "skip_mission_select", .type = CONFIG_TYPE_BOOL, .boolValue = &configSkipMissionSelect },
     { .name = "auto_switch_to_the_next_mission", .type = CONFIG_TYPE_BOOL, .boolValue = &configSwitchToNextMission },
     { .name = "skip_cutscenes", .type = CONFIG_TYPE_BOOL, .boolValue = &configSkipCutscenes },
+    { .name = "remain_mod", .type = CONFIG_TYPE_BOOL, .boolValue = &configRemainMod },
 
     { .name = "CAMERA", .type = CONFIG_TYPE_SECTION },
     { .name = "center_camera_button", .type = CONFIG_TYPE_BOOL, .boolValue = &configCenterCameraButton },


### PR DESCRIPTION
A progression mod for SM64Plus that allows players to complete each level without needing to exit and re-enter it.
It works by spawning in objects as necessary. Mostly objects from later acts, but also teleporters for when the player is stuck and can no longer progress.
It should be used with the option: 'Stay in Course After Getting a Star' set to ALWAYS.