### PR TITLE
Macos fixes

### DIFF
--- a/DEV_CHANGELOG.md
+++ b/DEV_CHANGELOG.md
@@ -1,15 +1,1 @@
-This is the changelog for the current development commit of the game. For the changelog for the public versions please check the Wiki
-
-
-# v3.1.0 (10/03/2023):
-
-### Additions:
-- Added the "Invisible Mode" setting, which makes Mario completely invisible.
-- Added the "Rock Paper Scissors" setting to the "For Fun" category, which changes Mario's victory animation.
-  
-### Fixes:
-- "Skip Cutscenes" setting no longer leaves a messed up model of Lakitu in front of the castle.
-- Fixed donut platforms ignoring the "Draw Distance" setting.
-- Fixed the "Draw Distance" setting sometimes getting set to "1x" by default instead of "Disabled".
-- Fixed a typo in the newly added secret dialog box.
-- Fixed a minor issue with the "Always Stay in Course" setting.
+This is the changelog for the current development commit of the game. For the changelog for the public versions please check the Wiki.

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ else ifeq ($(GRUCODE), f3dex2) # Fast3DEX2
   DEFINES += F3DEX_GBI_2=1 F3DEX_GBI_SHARED=1
 else ifeq ($(GRUCODE), f3dex2e) # Fast3DEX2 Extended (for PC)
   DEFINES += F3DEX_GBI_2E=1
-else ifeq ($(GRUCODE),f3dzex) # Fast3DZEX (2.0J / Animal Forest - D??butsu no Mori)
+else ifeq ($(GRUCODE),f3dzex) # Fast3DZEX (2.0J / Animal Forest - Dōbutsu no Mori)
   $(warning Fast3DZEX is experimental. Try at your own risk.)
   DEFINES += F3DZEX_GBI_2=1 F3DEX_GBI_2=1 F3DEX_GBI_SHARED=1
 endif

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,17 @@ ifeq ($(TARGET_N64),0)
   ifeq ($(TARGET_WEB),0)
     ifeq ($(shell uname -s),Darwin)
       TARGET_MACOS := 1
+      # Using Homebrew?
+      ifeq ($(shell which brew >/dev/null 2>&1 && echo y),y)
+        OSX_GCC_VER = $(shell find `brew --prefix`/bin/gcc* | grep -oE '[[:digit:]]+' | sort -n | uniq | tail -1)
+        CC := gcc-$(OSX_GCC_VER)
+	CXX := g++-$(OSX_GCC_VER)
+      # Using MacPorts?
+      else ifeq ($(shell test -d /opt/local/lib && echo y),y)
+        OSX_GCC_VER = $(shell find /opt/local/bin/gcc* | grep -oE '[[:digit:]]+' | sort -n | uniq | tail -1)
+	CC := gcc-mp-$(OSX_GCC_VER)
+	CXX := g++-mp-$(OSX_GCC_VER)
+      endif
     else
       ifeq ($(OS),Windows_NT)
         TARGET_WINDOWS := 1
@@ -110,7 +121,7 @@ else ifeq ($(GRUCODE), f3dex2) # Fast3DEX2
   DEFINES += F3DEX_GBI_2=1 F3DEX_GBI_SHARED=1
 else ifeq ($(GRUCODE), f3dex2e) # Fast3DEX2 Extended (for PC)
   DEFINES += F3DEX_GBI_2E=1
-else ifeq ($(GRUCODE),f3dzex) # Fast3DZEX (2.0J / Animal Forest - Dōbutsu no Mori)
+else ifeq ($(GRUCODE),f3dzex) # Fast3DZEX (2.0J / Animal Forest - D??butsu no Mori)
   $(warning Fast3DZEX is experimental. Try at your own risk.)
   DEFINES += F3DZEX_GBI_2=1 F3DEX_GBI_2=1 F3DEX_GBI_SHARED=1
 endif
@@ -431,8 +442,8 @@ else # TARGET_N64
 
 AS := as
 ifneq ($(TARGET_WEB),1)
-  CC := gcc
-  CXX := g++
+  CC ?= gcc
+  CXX ?= g++
 else
   CC := emcc
 endif
@@ -491,7 +502,7 @@ ifeq ($(TARGET_LINUX),1)
 endif
 ifeq ($(TARGET_MACOS),1)
   GFX_CFLAGS  +=
-  GFX_LDFLAGS += -framework OpenGL -lX11 -lSDL2
+  GFX_LDFLAGS += -framework OpenGL -lSDL2
 endif
 ifeq ($(TARGET_WEB),1)
   GFX_CFLAGS  += -s

--- a/src/pc/audio/audio_sdl2.c
+++ b/src/pc/audio/audio_sdl2.c
@@ -43,10 +43,14 @@ static int audio_sdl_get_desired_buffered(void) {
 
 static void audio_sdl_play(const uint8_t *buf, size_t len) {
     if (configOverallVolume > 0 && audio_sdl_buffered() < 6000) {
+#if TARGET_MACOS
+        SDL_QueueAudio(dev, buf, len);
+#else
         uint8_t *mix_buf[len];
         SDL_memset(mix_buf, 0, len);
         SDL_MixAudioFormat(mix_buf, buf, AUDIO_S16, len, SDL_MIX_MAXVOLUME * configOverallVolume);
         SDL_QueueAudio(dev, mix_buf, len);
+#endif
     }
 }
 


### PR DESCRIPTION
Here are the fixes required to allow compilation on macOS. Tested on an Apple MacBook M1 Pro running macOS Ventura v13.2.1 with GCC v12.2.0 (via Homebrew).

There is code to work with macports and homebrew but I've only tested homebrew.

This also includes a temporary workaround for silent audio on macOS.  I've tried troubleshooting but I can't figure it out.  [src/pc/audio/audio_sdl2.c](https://github.com/MorsGames/sm64plus/commit/60f0ac19558bf447279fa96e472653e9a2d572f5#diff-06856e515b8113c7b342b2d05a9d055cf725bcf5568b650c29617fb2036158b0) uses SDL_MixAudioFormat to adjust the volume based on the configOverallVolume setting.  The workaround is to bypass the mixer and volume adjustment (only for macOS).