### PR TITLE
Fix compilation error

### DIFF
--- a/tools/armips.cpp
+++ b/tools/armips.cpp
@@ -219,6 +219,7 @@ namespace tfm = tinyformat;
 
 #ifndef TINYFORMAT_ERROR
 #   include <cassert>
+#   include <cstdint>
 #   define TINYFORMAT_ERROR(reason) assert(0 && reason)
 #endif
 


### PR DESCRIPTION
Recently, there have been reports of SM64Plus failing to compile as soon as the compiling process starts. The error in question goes something like this: `armips.cpp:1414:34: note: 'int64_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'`. This PR fixes that.